### PR TITLE
Example project improvements

### DIFF
--- a/Example/CTNotificationContentExample/Info.plist
+++ b/Example/CTNotificationContentExample/Info.plist
@@ -33,6 +33,10 @@
 	<string>3cc-4bb</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -16,3 +16,13 @@ end
 target 'NotificationService' do
   pod "CTNotificationService"
 end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+      target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background
1. Resolve warning:
```
CTNotificationContentExample[670:122149] You've implemented -[<UIApplicationDelegate> application:didReceiveRemoteNotification:fetchCompletionHandler:], but you still need to add "remote-notification" to the list of your supported UIBackgroundModes in your Info.plist.
```
2. Resolve code signing of resource bundles when using CocoaPods

## Implementation
1. Add Background Modes: Remote notifications capability
2. Add `post_install` script to set codesigning to `NO` for resource bundles

## Testing steps
Manual
## Backward compatible
Yes