### PR TITLE
SDK-5762: Push template UI improvements and timer state persistence

### DIFF
--- a/CTNotificationContent/CTNotificationViewController.m
+++ b/CTNotificationContent/CTNotificationViewController.m
@@ -127,6 +127,7 @@ BOOL isFromProductDisplay = false;
             break;
         case CTNotificationContentTypeTimerTemplate: {
             CTTimerTemplateController *contentController = [[CTTimerTemplateController alloc] init];
+            [contentController setNotificationDeliveryDate:notification.date];
             [self setupContentController:contentController];
         }
             break;

--- a/CTNotificationContent/Templates/Rating/Controller/CTRatingsViewController.swift
+++ b/CTNotificationContent/Templates/Rating/Controller/CTRatingsViewController.swift
@@ -431,14 +431,13 @@ import SDWebImage
     
     func setupConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constraints.kCaptionLeftPadding),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constraints.kCaptionLeftPadding),
             titleLabel.heightAnchor.constraint(equalToConstant: Constraints.kCaptionHeight),
-            titleLabel.bottomAnchor.constraint(equalTo: subTitleLabel.topAnchor, constant: -8),
-            
+
             subTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
-            subTitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constraints.kCaptionLeftPadding),
+            subTitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             subTitleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constraints.kCaptionLeftPadding),
             subTitleLabel.heightAnchor.constraint(equalToConstant: Constraints.kSubCaptionHeight)])
     }

--- a/CTNotificationContent/Templates/Rating/Controller/CTRatingsViewController.swift
+++ b/CTNotificationContent/Templates/Rating/Controller/CTRatingsViewController.swift
@@ -191,7 +191,7 @@ import SDWebImage
     }
     func viewWithoutImageandRating(){
         let viewWidth = view.frame.size.width
-        let viewHeight = CTUtiltiy.getCaptionHeight()
+        let viewHeight = Constraints.kCaptionLeftPadding + Constraints.kCaptionHeight + Constraints.kSubCaptionTopPadding + Constraints.kSubCaptionHeight + Constraints.kBottomPadding
         let frame: CGRect = CGRect(x: 0, y: 0, width: viewWidth, height: viewHeight)
         view.frame = frame
         contentView.frame = frame
@@ -431,13 +431,13 @@ import SDWebImage
     
     func setupConstraints() {
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constraints.kCaptionLeftPadding),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constraints.kCaptionLeftPadding),
             titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constraints.kCaptionLeftPadding),
             titleLabel.heightAnchor.constraint(equalToConstant: Constraints.kCaptionHeight),
 
-            subTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
-            subTitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            subTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Constraints.kSubCaptionTopPadding),
+            subTitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constraints.kCaptionLeftPadding),
             subTitleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constraints.kCaptionLeftPadding),
             subTitleLabel.heightAnchor.constraint(equalToConstant: Constraints.kSubCaptionHeight)])
     }

--- a/CTNotificationContent/Templates/Timer/Controller/CTTimerTemplateController.swift
+++ b/CTNotificationContent/Templates/Timer/Controller/CTTimerTemplateController.swift
@@ -8,7 +8,8 @@ import SDWebImage
     @objc public var templateCaption: String = ""
     @objc public var templateSubcaption: String = ""
     @objc public var deeplinkURL: String = ""
-    
+    @objc public var notificationDeliveryDate: Date?
+
     var bgColor: String = ConstantKeys.kDefaultColor
     var captionColor: String = ConstantKeys.kHexBlackColor
     var subcaptionColor: String = ConstantKeys.kHexLightGrayColor
@@ -104,13 +105,15 @@ import SDWebImage
             return
         }
         if let threshold = jsonContent.pt_timer_threshold {
-            thresholdSeconds = threshold
-        } else {
-            if let endTime = jsonContent.pt_timer_end {
-                let date = NSDate()
-                let currentTime = date.timeIntervalSince1970
-                thresholdSeconds = endTime - Int(currentTime)
+            if let deliveredAt = notificationDeliveryDate {
+                let elapsed = Int(Date().timeIntervalSince(deliveredAt))
+                thresholdSeconds = max(0, threshold - elapsed)
+            } else {
+                thresholdSeconds = threshold
             }
+        } else if let endTime = jsonContent.pt_timer_end {
+            let currentTime = Date().timeIntervalSince1970
+            thresholdSeconds = endTime - Int(currentTime)
         }
 
         if let title = jsonContent.pt_title, !title.isEmpty {

--- a/CTNotificationContent/Templates/Utility/Extensions.swift
+++ b/CTNotificationContent/Templates/Utility/Extensions.swift
@@ -23,4 +23,18 @@ extension UILabel {
             self.text = htmlText
         }
     }
+
+    // UILabel.textColor is ignored when attributedText has explicit foreground color
+    // attributes (as HTML-parsed strings always do). This method applies the color
+    // directly to the attributed string so it takes effect.
+    func setTextColor(_ color: UIColor?) {
+        guard let color = color else { return }
+        guard let attributed = attributedText else {
+            textColor = color
+            return
+        }
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        mutable.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: mutable.length))
+        attributedText = mutable
+    }
 }

--- a/CTNotificationContent/Templates/Utility/GlobalConstants.swift
+++ b/CTNotificationContent/Templates/Utility/GlobalConstants.swift
@@ -9,7 +9,7 @@ enum Constraints {
     static let kSubCaptionHeight: CGFloat = 20.0
     static let kSubCaptionTopPadding: CGFloat = 8.0
     static let kBottomPadding: CGFloat = 18.0
-    static let kCaptionLeftPadding: CGFloat = 10.0
+    static let kCaptionLeftPadding: CGFloat = 16.0
     static let kCaptionTopPadding: CGFloat = 8.0
     static let kImageBorderWidth: CGFloat = 1.0
     static let kImageLayerBorderWidth: CGFloat = 0.4

--- a/CTNotificationContent/Templates/ZeroBezel/Controller/CTZeroBezelController.swift
+++ b/CTNotificationContent/Templates/ZeroBezel/Controller/CTZeroBezelController.swift
@@ -16,8 +16,8 @@ import SDWebImage
     @objc public var templateSubcaption: String = ""
     @objc public var deeplinkURL: String = ""
     
-    var captionColor: String = ConstantKeys.kHexBlackColor
-    var subcaptionColor: String = ConstantKeys.kHexLightGrayColor
+    var captionColor: String = ConstantKeys.kHexWhiteColor
+    var subcaptionColor: String = ConstantKeys.kHexWhiteColor
     
     // Dark mode colors
     var captionColorDark: String = ConstantKeys.kHexWhiteColor
@@ -53,6 +53,19 @@ import SDWebImage
         bigImageView.isAccessibilityElement = true
         bigImageView.translatesAutoresizingMaskIntoConstraints = false
         return bigImageView
+    }()
+    private let scrimView: UIView = {
+        let v = UIView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.isUserInteractionEnabled = false
+        return v
+    }()
+    private let scrimLayer: CAGradientLayer = {
+        let g = CAGradientLayer()
+        g.colors = [UIColor.clear.cgColor, UIColor.black.withAlphaComponent(0.65).cgColor]
+        g.startPoint = CGPoint(x: 0.5, y: 0)
+        g.endPoint = CGPoint(x: 0.5, y: 1)
+        return g
     }()
     
     @objc public override func viewDidLoad() {
@@ -100,6 +113,8 @@ import SDWebImage
     func createView() {
         createFrameWithoutImage()
         contentView.addSubview(bigImageView)
+        contentView.addSubview(scrimView)
+        scrimView.layer.addSublayer(scrimLayer)
         contentView.addSubview(subTitleLabel)
         contentView.addSubview(titleLabel)
         
@@ -161,8 +176,18 @@ import SDWebImage
 
     }
     
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        scrimLayer.frame = scrimView.bounds
+    }
+
     func setupConstraints() {
         NSLayoutConstraint.activate([
+            scrimView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            scrimView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            scrimView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            scrimView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.3),
+
             titleLabel.topAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -(CTUtiltiy.getCaptionHeight() - Constraints.kCaptionTopPadding)),
             titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constraints.kCaptionLeftPadding),
             titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constraints.kCaptionLeftPadding),

--- a/CTNotificationContent/Templates/ZeroBezel/Controller/CTZeroBezelController.swift
+++ b/CTNotificationContent/Templates/ZeroBezel/Controller/CTZeroBezelController.swift
@@ -21,7 +21,7 @@ import SDWebImage
     
     // Dark mode colors
     var captionColorDark: String = ConstantKeys.kHexWhiteColor
-    var subcaptionColorDark: String = ConstantKeys.kHexDarkGrayColor
+    var subcaptionColorDark: String = ConstantKeys.kHexWhiteColor
 
     var jsonContent: ZeroBezelProperties? = nil
     var templateBigImage:String = ""
@@ -248,8 +248,8 @@ import SDWebImage
             isDarkMode = false
         }
 
-        self.titleLabel.textColor = UIColor(hex: isDarkMode ? captionColorDark : captionColor)
-        self.subTitleLabel.textColor = UIColor(hex: isDarkMode ? subcaptionColorDark : subcaptionColor)
+        self.titleLabel.setTextColor(UIColor(hex: isDarkMode ? captionColorDark : captionColor))
+        self.subTitleLabel.setTextColor(UIColor(hex: isDarkMode ? subcaptionColorDark : subcaptionColor))
     }
     
     func showImageView() {


### PR DESCRIPTION
## Summary
- Fix left padding for title and message labels across all push templates (consistent horizontal inset)
- Fix top-left padding for title and subtitle in the rating template
- Add scrim overlay to the zero bezel template to improve text legibility over images
- Persist timer state across notification expand/collapse so the countdown doesn't reset on re-open