### PR TITLE
SDK-5993: make vertical image corner radius and border configurable

### DIFF
--- a/CTNotificationContent/Templates/VerticalImage/Controller/CTVerticalImageController.swift
+++ b/CTNotificationContent/Templates/VerticalImage/Controller/CTVerticalImageController.swift
@@ -64,7 +64,6 @@ import SDWebImage
         let imageView = SDAnimatedImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.layer.masksToBounds = true
-        imageView.layer.cornerRadius = 8.0
         imageView.isAccessibilityElement = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
@@ -156,6 +155,8 @@ import SDWebImage
 
         guard let json = jsonContent else { return }
 
+        configureImageStyle(json: json)
+
         // Resolve title and message from payload or system notification fields
         if let title = json.pt_title, !title.isEmpty { templateCaption = title }
         if let msg = json.pt_msg, !msg.isEmpty { templateSubcaption = msg }
@@ -216,6 +217,17 @@ import SDWebImage
         }
 
         updateInterfaceColors()
+    }
+
+    private func configureImageStyle(json: VerticalImageProperties) {
+        // Corner radius — default 8.0 preserves prior behavior when key is absent
+        bigImageView.layer.cornerRadius = CGFloat(json.pt_img_corner_radius?.value ?? 8.0)
+
+        // Border — only shown when a border color is provided
+        if let borderColor = json.pt_img_border_clr, !borderColor.isEmpty {
+            bigImageView.layer.borderColor = UIColor(hex: borderColor)?.cgColor
+            bigImageView.layer.borderWidth = CGFloat(json.pt_img_border_width?.value ?? 1.0)
+        }
     }
 
     private func configureButton(json: VerticalImageProperties) {

--- a/CTNotificationContent/Templates/VerticalImage/Model/VerticalImageProperties.swift
+++ b/CTNotificationContent/Templates/VerticalImage/Model/VerticalImageProperties.swift
@@ -24,6 +24,11 @@ struct VerticalImageProperties: Decodable {
     let pt_gif: String?
     let pt_scale_type: String?
 
+    // MARK: - Expanded Image
+    let pt_img_corner_radius: FlexibleDouble?
+    let pt_img_border_clr: String?
+    let pt_img_border_width: FlexibleDouble?
+
     // MARK: - Expanded Text Overlays
     let pt_text1: String?
     let pt_text1_clr: String?


### PR DESCRIPTION
## Summary

Made the vertical image corner radius, border color, and border width configurable via push payload keys (`pt_img_corner_radius`, `pt_img_border_clr`, `pt_img_border_width`). This mirrors the existing button border configuration pattern and allows templates to control image styling declaratively.

- Added three optional payload keys to `VerticalImageProperties`
- Moved hardcoded `cornerRadius = 8.0` to configurable setting with 8pt default (preserves existing behavior)
- Border only renders when `pt_img_border_clr` is provided; `pt_img_border_width` defaults to 1.0pt
- Reuses existing `FlexibleDouble` decoder and `UIColor(hex:)` color parser

## Test plan

Send vertical image push notifications with different payload configurations:
- No image keys → image shows 8pt rounded corners, no border (regression)
- `pt_img_corner_radius: 20` → visibly rounder corners
- `pt_img_border_clr: "#FF0000", pt_img_border_width: 3` → red 3pt border
- `pt_img_corner_radius: "16"` (string value) → confirm FlexibleDouble parsing
- All three keys combined → full styling control